### PR TITLE
Add Github CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+name: Build binaries
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        id: cache-1
+        uses: actions/cache@v2
+        with:
+          path: cache
+          key: ${{ runner.os }}-cache-1
+
+      - name: Download devkitPPC r37, libogc 2.1.0, bin2s, elf2dol, ppc-mxml 2.11 and libfat-ogc 1.1.5
+        if: steps.cache-1.outputs.cache-hit != 'true'
+        # general-tools is needed for bin2s and gamecube-tools is needed for elf2dol
+        run: | 
+          mkdir cache && cd cache
+          wget "https://wii.leseratte10.de/devkitPro/file.php/devkitPPC-r37-4-linux.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/libogc-2.1.0-1-any.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/general-tools-1.2.0-1-linux.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/gamecube-tools-1.0.2-1-linux.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/ppc-mxml-2.11-2-any.pkg.tar.xz"
+          wget "https://wii.leseratte10.de/devkitPro/file.php/libfat-ogc-1.1.5-2-any.pkg.tar.xz"
+          cd ..
+
+      - name: Extract all the archives
+        run: | 
+          tar -xf cache/devkitPPC-r37-4-linux.pkg.tar.xz opt/devkitpro/devkitPPC --strip-components=1
+          tar -xf cache/libogc-2.1.0-1-any.pkg.tar.xz opt/devkitpro/libogc --strip-components=1
+          tar -xf cache/libfat-ogc-1.1.5-2-any.pkg.tar.xz opt/devkitpro/libogc --strip-components=1
+          tar -xf cache/general-tools-1.2.0-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/bin2s --strip-components=4
+          sudo cp bin2s /usr/local/bin/bin2s
+          tar -xf cache/gamecube-tools-1.0.2-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/elf2dol --strip-components=4
+          sudo cp elf2dol /usr/local/bin/elf2dol
+          tar -xf cache/ppc-mxml-2.11-2-any.pkg.tar.xz opt/devkitpro/portlibs --strip-components=1
+
+      - name: Compile
+        run: |
+          PATH=$(pwd)/devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/devkitpro/devkitPPC DEVKITPRO=$(pwd)/devkitpro make install
+          cd modules
+          PATH=$(pwd)/../devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/../devkitpro/devkitPPC DEVKITPRO=$(pwd)/../devkitpro make 
+          cd ..
+          PATH=$(pwd)/devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/devkitpro/devkitPPC DEVKITPRO=$(pwd)/devkitpro make 
+          PATH=$(pwd)/devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/devkitpro/devkitPPC DEVKITPRO=$(pwd)/devkitpro make release
+          cp modules/*/bin/*.mod .
+
+      - name: Upload compiled Brainslug binaries
+        uses: actions/upload-artifact@v2
+        with: 
+          name: brainslug
+          path: |
+            release/apps
+            release/bslug
+            release/readme.txt
+
+      - name: Upload compiled modules
+        uses: actions/upload-artifact@v2
+        with: 
+          name: modules
+          path: |
+            *.mod
+            

--- a/BUILDING
+++ b/BUILDING
@@ -2,6 +2,7 @@ To build the BrainSlug channel you must first have a copy of devkitPro:
     http://sourceforge.net/projects/devkitpro/
 You must also have libmxml for devkitPro, which can be found here:
     http://wiibrew.org/wiki/Mini-XML
+You also need to have libfat installed.
 
 In the root directory of the BrainSlug repository, run the commands:
     make


### PR DESCRIPTION
This PR enabled Github CI for brainslug. 

When this is merged, Github will download all necessary stuff to compile brainslug from my server (devkitPPC r37, libogc 2.1.0, bin2s, elf2dol, ppc-mxml 2.11, libfat) and store it in the Github cache. 

Then for every commit, PR or merge that is done after that, Github will automatically take that stuff from its cache, spin up a Linux VM, install the dependencies, compile brainslug, then destroy the VM again. 

This gives an indication for every commit whether it could be compiled successfully, and it allows users to download compiled binaries for every commit. This also makes it easier for people to make changes to brainslug - just fork, edit and commit to your own fork, and Github will give you a binary without you having to set up a dev environment. 