### PR TITLE
Get rid of compiler warnings

### DIFF
--- a/modules/libfat/cache.c
+++ b/modules/libfat/cache.c
@@ -227,8 +227,8 @@ bool _FAT_cache_writePartialSector (CACHE* cache, const void* buffer, sec_t sect
     else
         memset(entry->cache + ((sec*cache->bytesPerSector) + offset),0,size);
         
-	entry->dirty = true;
-	return true;
+    entry->dirty = true;
+    return true;
 }
 
 bool _FAT_cache_writeLittleEndianValue (CACHE* cache, const uint32_t value, sec_t sector, unsigned int offset, int size) {
@@ -262,8 +262,8 @@ bool _FAT_cache_eraseWritePartialSector (CACHE* cache, const void* buffer, sec_t
     if (buffer != NULL)
         memcpy(entry->cache + ((sec*cache->bytesPerSector) + offset),buffer,size);
 
-	entry->dirty = true;
-	return true;
+    entry->dirty = true;
+    return true;
 }
 
 

--- a/modules/libfat/directory.c
+++ b/modules/libfat/directory.c
@@ -145,7 +145,7 @@ static size_t _FAT_directory_mbstoucs2 (ucs2_t* dst, const char* src, size_t len
 	int bytes;
 	size_t count = 0;
 
-	while (count < len-1 && src != '\0') {
+	while (count < len-1 && *src != '\0') {
 		bytes = mbrtowc (&tempChar, src, MB_CUR_MAX, &ps);
 		if (bytes > 0) {
 			*dst = (ucs2_t)tempChar;

--- a/src/libelf/elf_update.c
+++ b/src/libelf/elf_update.c
@@ -502,7 +502,7 @@ _libelf_resync_sections(Elf *e, off_t rc, struct _Elf_Extent_List *extents)
 static off_t
 _libelf_resync_elf(Elf *e, struct _Elf_Extent_List *extents)
 {
-	int ec, eh_class, eh_type;
+	int ec, eh_class, eh_type __attribute__((unused));
 	unsigned int eh_byteorder, eh_version;
 	size_t align, fsz;
 	size_t phnum, shnum;
@@ -707,7 +707,7 @@ _libelf_write_scn(Elf *e, char *nf, struct _Elf_Extent *ex)
 {
 	int ec;
 	Elf_Scn *s;
-	int elftype;
+	int elftype __attribute__((unused));
 	Elf_Data *d, dst;
 	uint32_t sh_type;
 	struct _Libelf_Data *ld;
@@ -922,9 +922,9 @@ static off_t
 _libelf_write_shdr(Elf *e, char *nf, struct _Elf_Extent *ex)
 {
 	int ec;
-	void *ehdr;
+	void *ehdr __attribute__((unused));
 	Elf_Scn *scn;
-	uint64_t shoff;
+	uint64_t shoff __attribute__((unused));
 	Elf32_Ehdr *eh32;
 	Elf64_Ehdr *eh64;
 	size_t fsz, nscn;

--- a/src/libelf/libelf_phdr.c
+++ b/src/libelf/libelf_phdr.c
@@ -38,7 +38,7 @@ ELFTC_VCSID("$Id: libelf_phdr.c 2225 2011-11-26 18:55:54Z jkoshy $");
 void *
 _libelf_getphdr(Elf *e, int ec)
 {
-	size_t phnum, phentsize;
+	size_t phnum, phentsize __attribute__((unused));
 	size_t fsz, msz;
 	uint64_t phoff;
 	Elf32_Ehdr *eh32;

--- a/src/modules/module.c
+++ b/src/modules/module.c
@@ -100,7 +100,7 @@ static module_metadata_t *Module_MetadataRead(
 static bool Module_ElfLoadSection(
     const Elf *elf, Elf_Scn *scn, const Elf32_Shdr *shdr, void *destination);
 static void Module_ElfLoadSymbols(
-    size_t shndx, const const void *destination, 
+    size_t shndx, const void *destination, 
     Elf32_Sym *symtab, size_t symtab_count);
 static bool Module_ElfLink(
     size_t index, Elf *elf, size_t shndx, void *destination,
@@ -821,7 +821,7 @@ static bool Module_ElfLoadSection(
 }
 
 static void Module_ElfLoadSymbols(
-        size_t shndx, const const void *destination,
+        size_t shndx, const void *destination,
         Elf32_Sym *symtab, size_t symtab_count) {
     
     size_t i;

--- a/src/search/symbol.c
+++ b/src/search/symbol.c
@@ -416,7 +416,7 @@ static symbol_relocation_t *Symbol_AddRelocation(
         assert(target != NULL);
         name_alloc = malloc(strlen(target) + 1);
         if (name_alloc != NULL) {
-            strncpy(name_alloc, target, strlen(target) + 1);
+            strcpy(name_alloc, target);
             relocation->symbol = name_alloc;
             relocation->type = type;
             relocation->offset = offset;


### PR DESCRIPTION
This fixes a bug in libfat (that the compiler found and gave a warning for) and also gets rid of a bunch of other compiler warnings. 