### PR TITLE
Use new libmxml, make tests pass again

### DIFF
--- a/src/search/symbol.c
+++ b/src/search/symbol.c
@@ -156,12 +156,12 @@ bool Symbol_ParseFile(FILE *file) {
             unsigned int i;
 
             data_size = 0;
-            xml_value = xml_data->child;
+            xml_value = mxmlGetFirstChild(xml_data);
             while (xml_value != NULL &&
-                   xml_value->type == MXML_TEXT &&
-                   xml_value->value.text.string != NULL) {
-                for (i = 0; xml_value->value.text.string[i] != '\0'; i++) {
-                    switch (xml_value->value.text.string[i]) {
+                   mxmlGetType(xml_value) == MXML_TEXT &&
+                   mxmlGetText(xml_value, 0) != NULL) {
+                for (i = 0; mxmlGetText(xml_value, 0)[i] != '\0'; i++) {
+                    switch (mxmlGetText(xml_value, 0)[i]) {
                         case '0': case '1': case '2': case '3': case '4':
                         case '5': case '6': case '7': case '8': case '9':
                         case 'a': case 'b': case 'c':
@@ -177,7 +177,7 @@ bool Symbol_ParseFile(FILE *file) {
                             goto next_symbol;
                     }
                 }
-                xml_value = xml_value->next;
+                xml_value = mxmlGetNextSibling(xml_value);
             }
 
             /* symbol must be in bytes, so two hex digits per byte! */
@@ -192,17 +192,17 @@ bool Symbol_ParseFile(FILE *file) {
                 goto next_symbol;
 
             data_size = 0;
-            xml_value = xml_data->child;
+            xml_value = mxmlGetFirstChild(xml_data);
             while (xml_value != NULL &&
-                   xml_value->type == MXML_TEXT &&
-                   xml_value->value.text.string != NULL) {
-                for (i = 0; xml_value->value.text.string[i] != '\0'; i++) {
-                    switch (xml_value->value.text.string[i]) {
+                   mxmlGetType(xml_value) == MXML_TEXT &&
+                   mxmlGetText(xml_value, 0) != NULL) {
+                for (i = 0; mxmlGetText(xml_value, 0)[i] != '\0'; i++) {
+                    switch (mxmlGetText(xml_value, 0)[i]) {
                         case '0': case '1': case '2': case '3': case '4':
                         case '5': case '6': case '7': case '8': case '9':
                             data[data_size / 2] =
                                 (data[data_size / 2] << 4) +
-                                (xml_value->value.text.string[i] - '0');
+                                (mxmlGetText(xml_value, 0)[i] - '0');
                             mask[data_size / 2] =
                                 (mask[data_size / 2] << 4) + 0xf;
                             data_size++;
@@ -211,7 +211,7 @@ bool Symbol_ParseFile(FILE *file) {
                         case 'd': case 'e': case 'f':
                             data[data_size / 2] =
                                 (data[data_size / 2] << 4) +
-                                (xml_value->value.text.string[i] - 'a' + 10);
+                                (mxmlGetText(xml_value, 0)[i] - 'a' + 10);
                             mask[data_size / 2] =
                                 (mask[data_size / 2] << 4) + 0xf;
                             data_size++;
@@ -220,7 +220,7 @@ bool Symbol_ParseFile(FILE *file) {
                         case 'D': case 'E': case 'F':
                             data[data_size / 2] =
                                 (data[data_size / 2] << 4) +
-                                (xml_value->value.text.string[i] - 'A' + 10);
+                                (mxmlGetText(xml_value, 0)[i] - 'A' + 10);
                             mask[data_size / 2] =
                                 (mask[data_size / 2] << 4) + 0xf;
                             data_size++;
@@ -239,7 +239,7 @@ bool Symbol_ParseFile(FILE *file) {
                             break;
                     }
                 }
-                xml_value = xml_value->next;
+                xml_value = mxmlGetNextSibling(xml_value);
             }
         } else {
             symbol->data = data = NULL;

--- a/test/fsm_test.c
+++ b/test/fsm_test.c
@@ -37,6 +37,8 @@ symbol_t fsm_test_symbol[4];
 #include <stdio.h>
 #include <stdint.h>
 
+// This looks unused:
+#if (0)
 static void FSMTest_Print(const fsm_t *fsm) {
     fsm_node_t *nodes[fsm->node_count];
     unsigned int i, j, found;
@@ -148,6 +150,7 @@ static void FSMTest_Print(const fsm_t *fsm) {
         }
     }
 }
+#endif
 
 int FSMTest_Create0(void) {
     fsm_t *fsm;

--- a/test/symbol_test.c
+++ b/test/symbol_test.c
@@ -22,9 +22,7 @@
  * SOFTWARE.
  */
  
-#ifdef _WIN32
-#define FMT_SIZE "I"
-#endif
+#define FMT_SIZE "z"
 
 #include "../src/search/symbol.c"
  


### PR DESCRIPTION
With the old libmxml 2.6, the tests failed on my Ubuntu Linux machine as Ubuntu (and other new Linux distributions) come with libmxml 3.x which got rid of a feature that libmxml 2.6 had (and which brainslug used). 

With this PR, Brainslug needs libmxml 2.11 (or newer) and the code has been rewritten to work both on libmxml 2.11 and on libmxml 3.x so that the tests pass again. 