### PR TITLE
Make games run on the proper IOS

### DIFF
--- a/src/apploader/apploader.h
+++ b/src/apploader/apploader.h
@@ -2,6 +2,7 @@
  *   by Alex Chadwick
  * 
  * Copyright (C) 2014, Alex Chadwick
+ * Copyright (C) 2020, Florian Bach
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -32,15 +33,39 @@
 
 typedef void (*apploader_game_entry_t)(void);
 
+extern event_t apploader_event_got_ios;
+extern event_t apploader_event_got_disc_id;
+extern event_t apploader_event_disc_loading;
+
 extern event_t apploader_event_disk_id;
 extern event_t apploader_event_complete;
+
 extern apploader_game_entry_t apploader_game_entry_fn;
 extern uint8_t *apploader_app0_start;
 extern uint8_t *apploader_app0_end;
 extern uint8_t *apploader_app1_start;
 extern uint8_t *apploader_app1_end;
 
+extern int _apploader_game_ios;
+
+typedef struct {
+    uint32_t offset;
+    uint32_t type;
+} partition_info_t;
+
+typedef struct {
+    uint32_t boot_info_count;
+    uint32_t partition_info_offset;
+} contents_t;
+
+extern partition_info_t *boot_partition;
+extern u32 apploader_ipc_tmd[0x4A00 / 4];
+extern contents_t ipc_toc[4];
+
+
 bool Apploader_Init(void);
-bool Apploader_RunBackground(void);
+bool Apploader_RunBackground(int tryForceIOS);
+bool IOSApploader_Init(void);
+bool IOSApploader_RunBackground(void);
 
 #endif /* APPLOADER_H_ */

--- a/src/apploader/apploader_get_ios.c
+++ b/src/apploader/apploader_get_ios.c
@@ -1,0 +1,184 @@
+/* apploader_get_ios.c
+ *   by Florian Bach, based on apploader.c by Alex Chadwick
+ * 
+ * Copyright (C) 2014, Alex Chadwick
+ * Copyright (C) 2020, Florian Bach
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// This is a modified and stripped-down version of the apploader code in 
+// apploader.c. It runs before the main apploader, and is responsible for
+// initializing the disc drive and figuring out what IOS the inserted
+// game needs to run. That information (the IOS number) is then returned 
+// to the main program, so a reload to that particular IOS can be performed.
+// After that, the full apploader in apploader.c takes over and loads
+// the game. 
+
+#include "apploader.h"
+
+#include <errno.h>
+#include <ogc/cache.h>
+#include <ogc/lwp.h>
+#include <ogc/lwp_watchdog.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "di/di.h"
+#include "library/dolphin_os.h"
+#include "library/event.h"
+#include "modules/module.h"
+#include "threads.h"
+
+
+
+event_t apploader_event_disc_loading;
+event_t apploader_event_got_ios;
+event_t apploader_event_got_disc_id;
+
+int _apploader_game_ios = 0;
+
+#define APPLOADER_APP0_BOUNDARY ((void *)0x81200000)
+#define APPLOADER_APP1_BOUNDARY ((void *)0x81400000)
+
+u32 apploader_ipc_tmd[0x4A00 / 4] ATTRIBUTE_ALIGN(32);
+
+static void *IOSApploader_Main(void *arg);
+
+bool IOSApploader_Init(void) {
+    return 
+        Event_Init(&apploader_event_got_ios) && 
+        Event_Init(&apploader_event_got_disc_id) && 
+        Event_Init(&apploader_event_disc_loading) ;
+}
+
+bool IOSApploader_RunBackground(void) {
+    int ret;
+    lwp_t thread;
+    
+    ret = LWP_CreateThread(
+        &thread, &IOSApploader_Main,
+        NULL, NULL, 0, THREAD_PRIO_IO);
+        
+    if (ret) {
+        errno = ENOMEM;
+        return false;
+    }
+    
+    return true;
+}
+
+void IOSApploader_Report(const char *format, ...) {
+#if 0
+    /* debugging code, uncomment to display apploader logging messages */
+    va_list args;
+
+    va_start(args, format);
+    vprintf(message, sizeof(message), format, args);
+    va_end(args);
+#endif
+}
+    
+partition_info_t *boot_partition;
+partition_info_t ipc_partition_info[4] ATTRIBUTE_ALIGN(32);
+contents_t ipc_toc[4] ATTRIBUTE_ALIGN(32);
+
+
+static void *IOSApploader_Main(void *arg) {
+    int ret, i;
+    
+    do {
+        ret = DI_Init();
+    } while (ret);
+
+    // wait until a disc is inserted, 
+    // then trigger the loading event, 
+    // then ... reset? Why?
+    while ((ret = DI_DiscInserted()) != 1) {
+        if (ret < 0) {
+            continue;
+        }
+        ;   // wait for disc to be inserted. 
+    }
+
+    Event_Trigger(&apploader_event_disc_loading);
+
+    do { 
+        ret = DI_Only_Reset(); 
+    } while (ret); 
+
+    do {
+        ret = DI_ReadDiscID();
+    } while (ret);
+        
+    Event_Trigger(&apploader_event_got_disc_id);
+    
+    do {
+        ret = DI_ReadUnencrypted(ipc_toc, sizeof(ipc_toc), 0x00010000);
+    } while (ret < 0);
+    DCInvalidateRange(ipc_toc, sizeof(ipc_toc));
+    do {
+        ret = DI_ReadUnencrypted(
+            ipc_partition_info, sizeof(ipc_partition_info),
+            ipc_toc->partition_info_offset);
+    } while (ret < 0);
+    
+    boot_partition = NULL;
+    for (i = 0; i < ipc_toc->boot_info_count; i++) {
+        if (ipc_partition_info[i].type == 0) {
+            boot_partition = &ipc_partition_info[i];
+        }
+    }
+
+    
+    do {
+        ret = DI_PartitionOpen(
+            boot_partition->offset, (void *)apploader_ipc_tmd);
+    } while (ret < 0);
+    
+    // Get IOS information
+    {
+        tmd *dvd_tmd;
+        
+        dvd_tmd = SIGNATURE_PAYLOAD(apploader_ipc_tmd);
+        
+        /* 
+        printf(
+            "Title ID: %08x-%.4s\nIOS: %08x-IOS%d\n",
+            (int)(dvd_tmd->title_id >> 32), (char *)&dvd_tmd->title_id + 4,
+            (int)(dvd_tmd->sys_version >> 32), (int)dvd_tmd->sys_version);
+        */
+
+        _apploader_game_ios = (int)dvd_tmd->sys_version;
+
+    }
+
+    // cleanup and close partition again so we don't have to re-init everything. 
+    do {
+        ret = DI_PartitionClose();
+    } while (ret < 0);
+
+    Event_Trigger(&apploader_event_got_ios);
+
+
+    
+    return NULL;
+}

--- a/src/apploader/makefile.mk
+++ b/src/apploader/makefile.mk
@@ -2,3 +2,4 @@ WD           := $(dir $(lastword $(MAKEFILE_LIST)))
 WD_APPLOADER := $(WD)
 
 SRC += $(WD)apploader.c
+SRC += $(WD)apploader_get_ios.c

--- a/src/di/di.h
+++ b/src/di/di.h
@@ -2,6 +2,7 @@
  *   by Alex Chadwick
  * 
  * Copyright (C) 2014, Alex Chadwick
+ * Copyright (C) 2020, Florian Bach
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +34,9 @@ int DI_Close(void);
 int DI_Read(void *buffer, uint32_t length, uint32_t offset);
 int DI_DiscWait(void);
 int DI_DiscInserted(void);
+int DI_ReadDiscID();
 int DI_Reset(void);
+int DI_Only_Reset(void);
 int DI_PartitionOpen(uint32_t offset, signed_blob *tmd);
 int DI_PartitionClose(void);
 int DI_ReadUnencrypted(void *buffer, uint32_t length, uint32_t offset);


### PR DESCRIPTION
This commit makes sure that Brainslug reloads into the correct IOS that's requested by the game before booting. The old version of Brainslug didn't do that, which broke USB support in a couple games. 

Also, it fixes a bug where certain out-of-region discs wouldn't boot properly due to an invalid video mode. 