### PR TITLE
Run tests in CI, and fail CI if tests fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,12 @@ jobs:
           tar -xf cache/gamecube-tools-1.0.2-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/elf2dol --strip-components=4
           sudo cp elf2dol /usr/local/bin/elf2dol
           tar -xf cache/ppc-mxml-2.11-2-any.pkg.tar.xz opt/devkitpro/portlibs --strip-components=1
+      
+      - name: Run tests
+        run: |
+          cd test
+          sudo apt install libmxml-dev
+          make
 
       - name: Compile
         run: |

--- a/test/Makefile
+++ b/test/Makefile
@@ -55,6 +55,8 @@ LIB_DIRS :=
 # Tests
 TEST     :=
 
+MAKEFLAGS += k
+
 ###############################################################################
 # Rule to make everything.
 PHONY += all
@@ -85,7 +87,7 @@ PHONY += regression
 regression : $(addprefix test_, $(TEST))
 	
 test_% : $(TARGET)
-	$Q{ $(TARGET) $* && echo "Test $* passed"; } || echo "Test $* failed ($$?)"
+	$Q{ $(TARGET) $* && echo "Test $* passed"; } || { echo "Test $* failed ($$?)"; false; }
 
 ###############################################################################
 # Special build rules


### PR DESCRIPTION
Now that the CI and all the test stuff is merged, here's another update for that: 

With this change to the CI pipeline, all the tests will also run for each commit, and the CI build will fail if any of the tests fail. 
The `MAKEFLAGS += k` makes sure that the tests continue even if one of them fails (so everything gets tested), and the `false` after a failed test is needed so the final return value of make returns an error so the CI build stops. 