### PR TITLE
Fix regression with getting the game ID

### DIFF
--- a/src/apploader/apploader.c
+++ b/src/apploader/apploader.c
@@ -185,6 +185,7 @@ static void *Aploader_Main(void *arg) {
         ret = DI_ReadDiscID();
     } while (ret);
 
+    Event_Trigger(&apploader_event_disk_id);
     
     do {
         ret = DI_ReadUnencrypted(ipc_toc, sizeof(ipc_toc), 0x00010000);


### PR DESCRIPTION
With the recent changes made to the apploader, having subdirectories in the modules or symbols folder would cause the application to softlock, as well as having a module that requires a specific game ID (e.g. rmc-local-net) in the modules folder.