### PR TITLE
Fix disc eject bug

### DIFF
--- a/src/apploader/apploader_get_ios.c
+++ b/src/apploader/apploader_get_ios.c
@@ -108,6 +108,8 @@ static void *IOSApploader_Main(void *arg) {
     do {
         ret = DI_Init();
     } while (ret);
+    
+    tryagain: 
 
     // wait until a disc is inserted, 
     // then trigger the loading event, 
@@ -124,9 +126,17 @@ static void *IOSApploader_Main(void *arg) {
     do { 
         ret = DI_Only_Reset(); 
     } while (ret); 
-
+    
     do {
         ret = DI_ReadDiscID();
+        if (ret) { 
+            if (DI_DiscInserted() != 1) {
+                // If the disc's missing, start over
+                usleep(2000);
+                goto tryagain;
+            }
+            usleep(2000);
+        }
     } while (ret);
         
     Event_Trigger(&apploader_event_got_disc_id);


### PR DESCRIPTION
Yeah ... interesting bug. 

If the user inserts the disc the wrong way (label side down), the channel hangs and you can no longer eject the disc to insert it correctly (The EJECT button no longer works). 

I assume this is because of the endless loop that calls DI_ReadDiscID over and over again. Adding a small usleep for the error case allows the user to eject the disc again, and the DI_DiscInserted check together with the goto allow the disc loading to restart once the user inserted the disc again - hopefully right-side up this time. 