### PR TITLE
Fix DI return code checks

### DIFF
--- a/src/apploader/apploader.c
+++ b/src/apploader/apploader.c
@@ -189,7 +189,7 @@ static void *Aploader_Main(void *arg) {
     
     do {
         ret = DI_ReadUnencrypted(ipc_toc, sizeof(ipc_toc), 0x00010000);
-    } while (ret < 0);
+    } while (ret != 1);
 
     DCInvalidateRange(ipc_toc, sizeof(ipc_toc));
     
@@ -197,7 +197,7 @@ static void *Aploader_Main(void *arg) {
         ret = DI_ReadUnencrypted(
             ipc_partition_info, sizeof(ipc_partition_info),
             ipc_toc->partition_info_offset);
-    } while (ret < 0);
+    } while (ret != 1);
     
     
     boot_partition = NULL;
@@ -210,7 +210,7 @@ static void *Aploader_Main(void *arg) {
     do {
         ret = DI_PartitionOpen(
             boot_partition->offset, (void *)apploader_ipc_tmd);
-    } while (ret < 0);
+    } while (ret != 1);
     
     #if 0
     /* debugging code */
@@ -229,11 +229,11 @@ static void *Aploader_Main(void *arg) {
     
     do {
         ret = DI_Read(ipc_buffer, sizeof(ipc_buffer), 0x2440 / 4);
-    } while (ret < 0);
+    } while (ret != 1);
     
     do {
         ret = DI_Read((void*)0x81200000, (ipc_buffer[5] + 31) & ~31, 0x2460 / 4);
-    } while (ret < 0);
+    } while (ret != 1);
     
     fn_entry = (apploader_entry_t)ipc_buffer[4];
     
@@ -291,7 +291,7 @@ static void *Aploader_Main(void *arg) {
 
         do {
             ret = DI_Read(destination, length, offset & ~3);
-        } while (ret < 0);
+        } while (ret != 1);
         
         DCFlushRange(destination, length);
     }

--- a/src/apploader/apploader_get_ios.c
+++ b/src/apploader/apploader_get_ios.c
@@ -133,13 +133,13 @@ static void *IOSApploader_Main(void *arg) {
     
     do {
         ret = DI_ReadUnencrypted(ipc_toc, sizeof(ipc_toc), 0x00010000);
-    } while (ret < 0);
+    } while (ret != 1);
     DCInvalidateRange(ipc_toc, sizeof(ipc_toc));
     do {
         ret = DI_ReadUnencrypted(
             ipc_partition_info, sizeof(ipc_partition_info),
             ipc_toc->partition_info_offset);
-    } while (ret < 0);
+    } while (ret != 1);
     
     boot_partition = NULL;
     for (i = 0; i < ipc_toc->boot_info_count; i++) {
@@ -152,7 +152,7 @@ static void *IOSApploader_Main(void *arg) {
     do {
         ret = DI_PartitionOpen(
             boot_partition->offset, (void *)apploader_ipc_tmd);
-    } while (ret < 0);
+    } while (ret != 1);
     
     // Get IOS information
     {
@@ -174,7 +174,7 @@ static void *IOSApploader_Main(void *arg) {
     // cleanup and close partition again so we don't have to re-init everything. 
     do {
         ret = DI_PartitionClose();
-    } while (ret < 0);
+    } while (ret != 1);
 
     Event_Trigger(&apploader_event_got_ios);
 


### PR DESCRIPTION
The old code retried DI_Read calls until the return value was not negative. However, that never happens. DI_Read and most other DI functions have 1 as the success case, and positive numbers larger than 1 for errors. This means that without this PR, reads could sometimes fail (due to disc issues or whatever), and instead of noticing and retrying, Brainslug would just assume that the data was read correctly. 