### PR TITLE
Add atof definition and symbol

### DIFF
--- a/bslug_include/stdlib.h
+++ b/bslug_include/stdlib.h
@@ -30,4 +30,6 @@
 
 #define MB_CUR_MAX 6
 
+double atof (const char* str);
+
 #endif /* _STDLIB_H_ */

--- a/symbols/stdlib.xml
+++ b/symbols/stdlib.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Symbols in the standard stdlib.h header -->
+<symbols>
+    <symbol name="atof" size="0x58" offset="0x1C" >
+        <data>
+            90 61 00 10 3c 60 80 00 38 63 ff ff
+        </data>
+    </symbol>
+</symbols>


### PR DESCRIPTION
This adds a definition and symbol for the `atof` stdlib function. The symbol has been checked against Rock Band 3 and Mario Kart Wii.